### PR TITLE
Fix x264 regex

### DIFF
--- a/Radarr/Collection-of-Custom-Formats-for-Radarr.md
+++ b/Radarr/Collection-of-Custom-Formats-for-Radarr.md
@@ -43,7 +43,7 @@
 
 ![](images/image-20200307121316716.png)
 
-> x264 = `C_RX_(X|H)\?264`
+> x264 = `C_RX_(X|H)\.?264`
 >
 > If you prefer x264 releases (Encodes).
 ------


### PR DESCRIPTION
The image for x264 regex was correct but the text was missing a period.