### PR TITLE
Update Collection-of-Custom-Formats-for-RadarrV3.md

### DIFF
--- a/RadarrV3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/RadarrV3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -189,7 +189,7 @@ Required: `False`
 
  IMG Needed
 #### Low-Quality Releases (often banned groups)[BLOCK1]
-Release Title: /b-aXXo|-CrEwSaDe|-DEViSE|-FaNGDiNG0|-FLAWL3SS|-FZHD|-FRDS|-HDTime|-IMAGINE|-iPlanet|-KingBen|-KiNGDOM|-KLAXXON|-Leffe|-LTRG|-mHD|-mSD|-NhaNc3|-nHD|-nikt0|-nSD|-PrisM|-PRODJi|-Rx|-RDN|-SANTi|-ViSION|-WAF|-WHiiZz|-x0r|-YIFY|-STUTTERSHIT/b
+Release Title: /b-aXXo|-CrEwSaDe|-DEViSE|-FaNGDiNG0|-FLAWL3SS|-FZHD|-FRDS|-HDTime|-IMAGINE|-iPlanet|-KingBen|-KiNGDOM|-KLAXXON|-Leffe|-LTRG|-mHD|-mSD|-NhaNc3|-nHD|-nikt0|-nSD|-PrisM|-PRODJi|-Rx|-RDN|-SANTi|-ViSION|-WAF|-WHiiZz|-x0r|-YIFY|-YTS|-STUTTERSHIT/b
 Negate: `False`
 Required: `True`
 


### PR DESCRIPTION
add -YTS to Block 1 (YIFY AKA)

Should these be "YTS" and "YIFY" the releases are not always "-YTS" or "-YIFY"?